### PR TITLE
Add Always on top checkbox.

### DIFF
--- a/DirectXHost.cs
+++ b/DirectXHost.cs
@@ -151,7 +151,7 @@ namespace DirectXHost
 			if (Settings.savePositions) _overlayForm.Location = Settings.overlayRect.Point;
 			_overlayForm.BackColor = Settings.transparencyKey;
 			_overlayForm.TransparencyKey = Settings.transparencyKey;
-			_overlayForm.TopMost = true;
+			_overlayForm.TopMost = Settings.topMost;
 			_overlayForm.ShowIcon = false;
 			_overlayForm.MinimizeBox = true;
 			_overlayForm.MaximizeBox = true;
@@ -225,6 +225,11 @@ If you have issues with the window positions/sizes, delete the 'props.bin' file 
 				}),
 				new MenuItem($"{(Settings.savePositions ? '☑' : '☐')} Save Window Positions", (s,e) => {
 					Settings.savePositions = !Settings.savePositions;
+					_dxForm.Menu = GetMenu();
+					Settings.Save();
+				}),
+				new MenuItem($"{(Settings.topMost ? '☑' : '☐')} Always On Top", (s,e) => {
+					Settings.topMost = !Settings.topMost;
 					_dxForm.Menu = GetMenu();
 					Settings.Save();
 				}),

--- a/Settings.cs
+++ b/Settings.cs
@@ -14,6 +14,7 @@ namespace DirectXHost
 		{
 			public bool overlayClickable;
 			public bool savePositions;
+			public bool topMost;
 			public Rect overlayRect;
 			public Rect containerRect;
 			public Color transparencyKey;
@@ -30,6 +31,11 @@ namespace DirectXHost
 		{
 			get => data.savePositions;
 			set => data.savePositions = value;
+		}
+		public static bool topMost
+		{
+			get => data.topMost;
+			set => data.topMost = value;
 		}
 		public static Rect overlayRect
 		{
@@ -55,6 +61,7 @@ namespace DirectXHost
 				{
 					overlayClickable = true,
 					savePositions = false,
+					topMost = true,
 					overlayRect = new Rect { Size = new Size(Constants.OverlayStartWidth, Constants.OverlayStartHeight), Point = Point.Empty },
 					containerRect = new Rect { Size = new Size(Constants.StartWidth, Constants.StartHeight), Point = Point.Empty },
 					transparencyKey = Constants.DefaultTransparencyKey


### PR DESCRIPTION
On by default (as it was).
If changed, needs to restart the overlay to take effect.

Was usefull to me as i use the discord overlay alongside Rainmetter to have a "wallpaper dashboard"