### PR TITLE
Minor bugfixes

### DIFF
--- a/DirectXHost.cs
+++ b/DirectXHost.cs
@@ -136,7 +136,6 @@ namespace DirectXHost
 			long drawingTime = stopWatch.ElapsedTicks;
 			
 			int frameRate = Settings.frameRate;
-
 			if (frameRate > 0)
 			{
 				int framerateTicks = 10000000 / frameRate;

--- a/DirectXHost.cs
+++ b/DirectXHost.cs
@@ -8,195 +8,224 @@ using System.Windows.Forms;
 using System.Linq;
 using DirectXHost.Extensions;
 using System.Threading;
+using System.Reflection;
+using System.ComponentModel;
 
 namespace DirectXHost
 {
-	public class DirectXHost : IDisposable
-	{
-		[DllImport("user32")]
-		private static extern int PrintWindow(IntPtr hwnd, IntPtr hdcBlt, UInt32 nFlags);
-		[DllImport("user32.dll", SetLastError = true)]
-		static extern int SetWindowLong(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
-		[DllImport("user32.dll", SetLastError = true)]
-		static extern IntPtr FindWindow(string lpWindowClass, string lpWindowName);
-		[DllImport("user32.dll", SetLastError = true)]
-		static extern IntPtr FindWindowEx(IntPtr parentHandle, IntPtr childAfter, string className, string windowTitle);
-		private const int GWL_HWNDPARENT = -8;
+    public class DirectXHost : IDisposable
+    {
+        public const int GWL_EXSTYLE = -20;
+        public const uint WS_EX_LAYERED = 0x00080000;
+        public const uint WS_EX_TRANSPARENT = 0x00000020;
 
-		private Form _overlayForm;
-		private PictureBox _overlayTarget;
-		private RenderForm _dxForm;
-		private GraphicsD3D11 _graphics;
-		private long time = DateTime.Now.Ticks;
-		private bool UserResized { get; set; }
-		private Size ClientSize { get; set; }
+        [DllImport("user32.dll", SetLastError = true)]
+        static extern int GetWindowLong(IntPtr hWnd, int nIndex);
 
-		public bool IsDisposed { get; private set; }
+        [DllImport("user32.dll")]
+        static extern int SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
 
-		#region Events
-		public event EventHandler HostWindowClosed;
-		public event EventHandler HostWindowCreated;
-		protected void OnHostWindowCreated()
-		{
-			if (HostWindowCreated != null)
-			{
-				HostWindowCreated(this._dxForm, new EventArgs());
-			}
-		}
+        [DllImport("user32.dll")]
+        static extern bool SetLayeredWindowAttributes(IntPtr hwnd, uint crKey, byte bAlpha, uint dwFlags);
 
-		protected void OnHostWindowClosed()
-		{
-			if (HostWindowClosed != null)
-			{
-				HostWindowClosed(this._dxForm, new EventArgs());
-			}
-		}
-		#endregion
+        [DllImport("user32")]
+        private static extern int PrintWindow(IntPtr hwnd, IntPtr hdcBlt, UInt32 nFlags);
+        [DllImport("user32.dll", SetLastError = true)]
+        static extern int SetWindowLong(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+        [DllImport("user32.dll", SetLastError = true)]
+        static extern IntPtr FindWindow(string lpWindowClass, string lpWindowName);
+        [DllImport("user32.dll", SetLastError = true)]
+        static extern IntPtr FindWindowEx(IntPtr parentHandle, IntPtr childAfter, string className, string windowTitle);
+        private const int GWL_HWNDPARENT = -8;
+
+        private OverlayForm _overlayForm;
+        private PictureBox _overlayTarget;
+        private RenderForm _dxForm;
+        private GraphicsD3D11 _graphics;
+        private long time = DateTime.Now.Ticks;
+        private bool UserResized { get; set; }
+        private Size ClientSize { get; set; }
+
+        public bool IsDisposed { get; private set; }
+
+        #region Events
+        public event EventHandler HostWindowClosed;
+        public event EventHandler HostWindowCreated;
+        protected void OnHostWindowCreated()
+        {
+            if (HostWindowCreated != null)
+            {
+                HostWindowCreated(this._dxForm, new EventArgs());
+            }
+        }
+
+        protected void OnHostWindowClosed()
+        {
+            if (HostWindowClosed != null)
+            {
+                HostWindowClosed(this._dxForm, new EventArgs());
+            }
+        }
+        #endregion
 
 
-		public void Exit()
-		{
-			throw new NotImplementedException();
-		}
+        public void Exit()
+        {
+            throw new NotImplementedException();
+        }
 
-		public async Task Run()
-		{
-			try
-			{
-				await Settings.Load();
-				InitializeRenderForm();
+        public async Task Run()
+        {
+            try
+            {
+                await Settings.Load();
+                InitializeRenderForm();
 
-				_graphics = new GraphicsD3D11();
-				_graphics.Initialise(_dxForm, true);
-				_dxForm.UserResized += (sender, args) =>
-				{
-					var renderForm = sender as RenderForm;
-					ClientSize = new Size(renderForm.ClientSize.Width, renderForm.ClientSize.Height);
-					UserResized = true;
-				};
-				_overlayForm.Show();
-				RenderLoop.Run(_dxForm, RenderCallback, true);
-			}
-			catch (ArgumentException ex)
-			{
-				MessageBox.Show(string.Format("Exception running DirectX host window.\r\n{0}", ex.Message), "DirectX Host", MessageBoxButtons.OK, MessageBoxIcon.Error);
-			}
-			catch (Exception ex)
-			{
-				MessageBox.Show(string.Format("Exception running DirectX host window.\r\n{0}", ex.Message), "DirectX Host", MessageBoxButtons.OK, MessageBoxIcon.Error);
-			}
-		}
+                _graphics = new GraphicsD3D11();
+                _graphics.Initialise(_dxForm, true);
+                _dxForm.UserResized += (sender, args) =>
+                {
+                    var renderForm = sender as RenderForm;
+                    ClientSize = new Size(renderForm.ClientSize.Width, renderForm.ClientSize.Height);
+                    UserResized = true;
+                };
+                _overlayForm.Show();
+                RenderLoop.Run(_dxForm, RenderCallback, true);
+            }
+            catch (ArgumentException ex)
+            {
+                MessageBox.Show(string.Format("Exception running DirectX host window.\r\n{0}", ex.Message), "DirectX Host", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(string.Format("Exception running DirectX host window.\r\n{0}", ex.Message), "DirectX Host", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
 
-		// Set the bitmap object to the size of the screen
-		private Bitmap _bmpScreenshot;
-		Bitmap bmpScreenshot
-		{
-			get => _bmpScreenshot;
-			set
-			{
-				_bmpScreenshot = value;
-				_overlayTarget.Image = value;
-				updateImageBounds();
-			}
-		}
+        // Set the bitmap object to the size of the screen
+        private Bitmap _bmpScreenshot;
+        Bitmap bmpScreenshot
+        {
+            get => _bmpScreenshot;
+            set
+            {
+                _bmpScreenshot = value;
+                _overlayTarget.Image = value;
+                updateImageBounds();
+            }
+        }
 
-		Graphics gfxScreenshot;
-		private void RenderCallback()
-		{
-			if (_dxForm.WindowState == FormWindowState.Normal)
-			{
-				Update();
-				Draw();
-				gfxScreenshot = Graphics.FromImage(bmpScreenshot);
-				IntPtr dc = gfxScreenshot.GetHdc();
-				PrintWindow(_dxForm.Handle, dc, 0);
-				gfxScreenshot.ReleaseHdc();
-				gfxScreenshot.Dispose();
-				_overlayTarget.Invalidate();
-			}
-			// Calculate Frame Limiting
-			long end = DateTime.Now.Ticks;
-			long duration = end - time;
-			int timeout = (1000 / 10) - (int)new TimeSpan(duration).TotalMilliseconds;
-			if (timeout > 0)
-				Thread.Sleep(timeout);
-		}
+        Graphics gfxScreenshot;
+        private void RenderCallback()
+        {
+            if (_dxForm.WindowState == FormWindowState.Normal)
+            {
+                Update();
+                Draw();
+                gfxScreenshot = Graphics.FromImage(bmpScreenshot);
+                IntPtr dc = gfxScreenshot.GetHdc();
+                PrintWindow(_dxForm.Handle, dc, 0);
+                gfxScreenshot.ReleaseHdc();
+                gfxScreenshot.Dispose();
+                _overlayTarget.Invalidate();
+            }
+            // Calculate Frame Limiting
+            long end = DateTime.Now.Ticks;
+            long duration = end - time;
+            int timeout = (1000 / 10) - (int)new TimeSpan(duration).TotalMilliseconds;
+            if (timeout > 0)
+                Thread.Sleep(timeout);
+        }
 
-		class OverlayForm : Form
-		{
-			public OverlayForm() : base()
-			{
-				DoubleBuffered = true;
-			}
-		}
+        class OverlayForm : Form
+        {
+            private int PreviousStyle;
 
-		private bool _drag = false;
-		private Point _wstart, _mstart;
+            public OverlayForm() : base()
+            {
+                DoubleBuffered = true;
+            }
+            public void SetFormTransparent()
+            {
+                IntPtr Handle = this.Handle;
+                PreviousStyle = GetWindowLong(Handle, GWL_EXSTYLE);
+                SetWindowLong(Handle, GWL_EXSTYLE, Convert.ToInt32(PreviousStyle | WS_EX_LAYERED | WS_EX_TRANSPARENT));
+            }
 
-		private void updateImageBounds()
-		{
-			_overlayTarget.Size = _dxForm.Size;
-			int BorderWidth = (_dxForm.Width - _dxForm.ClientSize.Width) / 2;
-			int TitlebarHeight = (_dxForm.Height - _dxForm.ClientSize.Height) - BorderWidth;
-			_overlayTarget.Location = new Point(-BorderWidth, -TitlebarHeight);
-			_overlayTarget.Width = _dxForm.Width - BorderWidth;
-			_overlayTarget.Height = _dxForm.Height - BorderWidth;
-			_overlayTarget.Invalidate();
-		}
+            public void SetFormNormal()
+            {
+                IntPtr Handle = this.Handle;
 
-		private void InitializeRenderForm()
-		{
-			SizeF scaledSize;
-			_dxForm = new RenderForm(Constants.WindowTitle);
-			using (var gfx = _dxForm.CreateGraphics())
-			{
-				scaledSize = new SizeF(gfx.DpiX / 96, gfx.DpiY / 96);
-			}
-			_dxForm.HandleCreated += WindowHandleCreated;
-			_dxForm.HandleDestroyed += WindowHandleDestroyed;
-			_dxForm.MinimumSize = new Size((int)(Constants.StartWidth * scaledSize.Width), (int)(Constants.StartHeight * scaledSize.Height));
-			_dxForm.ClientSize = Settings.savePositions ? Settings.containerRect.Size : _dxForm.MinimumSize;
-			_dxForm.StartPosition = Settings.savePositions ? FormStartPosition.Manual : FormStartPosition.CenterScreen;
-			if (Settings.savePositions) _dxForm.Location = Settings.containerRect.Point;
-			_dxForm.FormBorderStyle = FormBorderStyle.SizableToolWindow;
-			_dxForm.GotFocus += (s, e) => ShouldShowOverlayFrame(true);
-			_dxForm.LostFocus += (s, e) => ShouldShowOverlayFrame(false);
-			_dxForm.TopMost = false;
-			_dxForm.HelpRequested += _dxForm_HelpRequested;
-			_dxForm.Menu = GetMenu();
-			_dxForm.UserResized += (sender, args) => { Settings.containerRect.Size = _dxForm.ClientSize; Settings.Save(); };
-			_dxForm.LocationChanged += (sender, args) => { Settings.containerRect.Point = _dxForm.Location; Settings.Save(); };
+                SetWindowLong(Handle, GWL_EXSTYLE, Convert.ToInt32(PreviousStyle | WS_EX_LAYERED));
+            }
+        }
+        private bool _drag = false;
+        private Point _wstart, _mstart;
 
-			IntPtr hprog = FindWindowEx(FindWindowEx(FindWindow("Discord Overlay", "Program Manager"), IntPtr.Zero, "SHELLDLL_DefView", ""), IntPtr.Zero, "SysListView32", "FolderView");
-			SetWindowLong(_dxForm.Handle, GWL_HWNDPARENT, hprog);
+        private void updateImageBounds()
+        {
+            _overlayTarget.Size = _dxForm.Size;
+            int BorderWidth = (_dxForm.Width - _dxForm.ClientSize.Width) / 2;
+            int TitlebarHeight = (_dxForm.Height - _dxForm.ClientSize.Height) - BorderWidth;
+            _overlayTarget.Location = new Point(-BorderWidth, -TitlebarHeight);
+            _overlayTarget.Width = _dxForm.Width - BorderWidth;
+            _overlayTarget.Height = _dxForm.Height - BorderWidth;
+            _overlayTarget.Invalidate();
+        }
 
-			_overlayForm = new OverlayForm();
-			_overlayForm.Text = _overlayForm.Name = "Discord Overlay";
-			_overlayForm.MinimumSize = new Size(100, 50);
-			_overlayForm.ClientSize = Settings.savePositions ? Settings.overlayRect.Size : new Size(Constants.OverlayStartWidth, Constants.OverlayStartHeight);
-			_overlayForm.StartPosition = Settings.savePositions ? FormStartPosition.Manual : FormStartPosition.CenterScreen;
-			if (Settings.savePositions) _overlayForm.Location = Settings.overlayRect.Point;
-			_overlayForm.BackColor = Settings.transparencyKey;
-			_overlayForm.TransparencyKey = Settings.transparencyKey;
-			_overlayForm.TopMost = true;
-			_overlayForm.ShowIcon = false;
-			_overlayForm.MinimizeBox = true;
-			_overlayForm.MaximizeBox = true;
-			_overlayForm.BackgroundImageLayout = ImageLayout.None;
-			_overlayForm.FormBorderStyle = FormBorderStyle.Sizable;
-			_overlayForm.FormClosing += (s, e) => _dxForm.Close();
-			_overlayForm.GotFocus += (s, e) => ShouldShowOverlayFrame(true);
-			_overlayForm.LostFocus += (s, e) => ShouldShowOverlayFrame(false);
-			_overlayTarget = new PictureBox();
-			_overlayTarget.SizeMode = PictureBoxSizeMode.Normal;
-			_overlayTarget.BackColor = Color.Red;
-			_overlayTarget.Anchor = AnchorStyles.Top | AnchorStyles.Left;
-			_overlayForm.Controls.Add(_overlayTarget);
-			_overlayForm.ResizeEnd += (sender, args) => { Settings.overlayRect.Size = _overlayForm.ClientSize; Settings.Save(); };
-			_overlayForm.LocationChanged += (sender, args) => { Settings.overlayRect.Point = _overlayForm.Location; Settings.Save(); };
+        private void InitializeRenderForm()
+        {
+            SizeF scaledSize;
+            _dxForm = new RenderForm(Constants.WindowTitle);
+            using (var gfx = _dxForm.CreateGraphics())
+            {
+                scaledSize = new SizeF(gfx.DpiX / 96, gfx.DpiY / 96);
+            }
+            _dxForm.HandleCreated += WindowHandleCreated;
+            _dxForm.HandleDestroyed += WindowHandleDestroyed;
+            _dxForm.MinimumSize = new Size((int)(Constants.StartWidth * scaledSize.Width), (int)(Constants.StartHeight * scaledSize.Height));
+            _dxForm.ClientSize = Settings.savePositions ? Settings.containerRect.Size : _dxForm.MinimumSize;
+            _dxForm.StartPosition = Settings.savePositions ? FormStartPosition.Manual : FormStartPosition.CenterScreen;
+            if (Settings.savePositions) _dxForm.Location = Settings.containerRect.Point;
+            _dxForm.FormBorderStyle = FormBorderStyle.SizableToolWindow;
+            _dxForm.GotFocus += (s, e) => ShouldShowOverlayFrame(true);
+            _dxForm.LostFocus += (s, e) => ShouldShowOverlayFrame(false);
+            _dxForm.TopMost = false;
+            _dxForm.HelpRequested += _dxForm_HelpRequested;
+            _dxForm.Menu = GetMenu();
+            _dxForm.UserResized += (sender, args) => { Settings.containerRect.Size = _dxForm.ClientSize; Settings.Save(); };
+            _dxForm.LocationChanged += (sender, args) => { Settings.containerRect.Point = _dxForm.Location; Settings.Save(); };
 
-			// Set the bitmap object to the size of the screen
-			bmpScreenshot = new Bitmap(_dxForm.Width, _dxForm.Height, PixelFormat.Format32bppArgb);
+            IntPtr hprog = FindWindowEx(FindWindowEx(FindWindow("Discord Overlay", "Program Manager"), IntPtr.Zero, "SHELLDLL_DefView", ""), IntPtr.Zero, "SysListView32", "FolderView");
+            SetWindowLong(_dxForm.Handle, GWL_HWNDPARENT, hprog);
+
+            _overlayForm = new OverlayForm();
+            _overlayForm.Text = _overlayForm.Name = "Discord Overlay";
+            _overlayForm.MinimumSize = new Size(100, 50);
+            _overlayForm.ClientSize = Settings.savePositions ? Settings.overlayRect.Size : new Size(Constants.OverlayStartWidth, Constants.OverlayStartHeight);
+            _overlayForm.StartPosition = Settings.savePositions ? FormStartPosition.Manual : FormStartPosition.CenterScreen;
+            if (Settings.savePositions) _overlayForm.Location = Settings.overlayRect.Point;
+            _overlayForm.BackColor = Settings.transparencyKey;
+            _overlayForm.TransparencyKey = Settings.transparencyKey;
+            _overlayForm.TopMost = true;
+            _overlayForm.ShowIcon = false;
+            _overlayForm.MinimizeBox = true;
+            _overlayForm.MaximizeBox = true;
+            _overlayForm.BackgroundImageLayout = ImageLayout.None;
+            _overlayForm.FormBorderStyle = FormBorderStyle.Sizable;
+            _overlayForm.FormClosing += (s, e) => _dxForm.Close();
+            _overlayForm.GotFocus += (s, e) => ShouldShowOverlayFrame(true);
+            _overlayForm.LostFocus += (s, e) => ShouldShowOverlayFrame(false);
+            _overlayTarget = new PictureBox();
+            _overlayTarget.SizeMode = PictureBoxSizeMode.Normal;
+            _overlayTarget.BackColor = Color.Red;
+            _overlayTarget.Anchor = AnchorStyles.Top | AnchorStyles.Left;
+            _overlayForm.Controls.Add(_overlayTarget);
+            _overlayForm.ResizeEnd += (sender, args) => { Settings.overlayRect.Size = _overlayForm.ClientSize; Settings.Save(); };
+            _overlayForm.LocationChanged += (sender, args) => { Settings.overlayRect.Point = _overlayForm.Location; Settings.Save(); };
+
+            // Set the bitmap object to the size of the screen
+            bmpScreenshot = new Bitmap(_dxForm.Width, _dxForm.Height, PixelFormat.Format32bppArgb);
 
 			_dxForm.MouseDown += (s, e) =>
 			{
@@ -227,11 +256,11 @@ namespace DirectXHost
 				var delta = new Point(newPoint.X - _mstart.X, newPoint.Y - _mstart.Y);
 				_overlayForm.Location = _overlayForm.PointToScreen(new Point(_wstart.X + delta.X, _wstart.Y + delta.Y));
 			};
-		}
+        }
 
-		private void _dxForm_HelpRequested(object sender, EventArgs eventArgs)
-		{
-			MessageBox.Show(_dxForm, @"Overlay Clickable: Enables/Disables ability to interact with the Overlay Window.
+        private void _dxForm_HelpRequested(object sender, EventArgs eventArgs)
+        {
+            MessageBox.Show(_dxForm, @"Overlay Clickable: Enables/Disables ability to interact with the Overlay Window.
 
 Save Window Positions: Saves the Overlay and Container sizes and screen positions.
 
@@ -241,134 +270,136 @@ FPS: The rate at which the Discord Overlay refreshes. This is defaulted to 10 ti
 
 If you have issues with the window positions/sizes, delete the 'props.bin' file that is generated in the program's folder. This will reset the program settings.
 ", "Help", MessageBoxButtons.OK, MessageBoxIcon.Question);
-		}
-		private int ColorToBgr(Color color) => (color.B << 16) | (color.G << 8) | color.R;
-		private MainMenu GetMenu() => new MainMenu(new MenuItem[]
-			{
-				new MenuItem("?", _dxForm_HelpRequested),
-				new MenuItem($"{(Settings.overlayClickable ? '☑' : '☐')} Overlay Clickable", (menuItem,e) => {
-					Settings.overlayClickable = !Settings.overlayClickable;
-					ShouldShowOverlayFrame(Settings.overlayClickable);
-					Settings.Save();
-					(menuItem as MenuItem).Text = $"{(Settings.overlayClickable ? '☑' : '☐')} Overlay Clickable";
-				}),
-				new MenuItem($"{(Settings.savePositions ? '☑' : '☐')} Save Window Positions", (menuItem,e) => {
-					Settings.savePositions = !Settings.savePositions;
-					Settings.Save();
-					(menuItem as MenuItem).Text = $"{(Settings.savePositions ? '☑' : '☐')} Save Window Positions";
-				}),
-				new MenuItem("Transparency Colour", (menuItem,e) =>
-				{
-					var dialog = new ColorDialog();
-					dialog.Color = Settings.transparencyKey;
-					dialog.SolidColorOnly = true;
-					dialog.AnyColor = true;
-					dialog.FullOpen = true;
-					dialog.CustomColors = new int[] { ColorToBgr(Constants.DefaultTransparencyKey), ColorToBgr(Settings.transparencyKey) };
-					if(dialog.ShowDialog(_dxForm) == DialogResult.OK)
-					{
-						Settings.transparencyKey = dialog.Color;
-						Settings.Save();
-						ShouldShowOverlayFrame(true);
-					}
-				}),
-				new MenuItem($"{Settings.frameRate} FPS", (menuItem, e) => {
-					switch(Settings.frameRate)
-					{
-						case 5: Settings.frameRate = 10; break;
-						case 10: Settings.frameRate = 20; break;
-						case 20: Settings.frameRate = 30; break;
-						case 30: Settings.frameRate = 5; break;
-					}
-					Settings.Save();
-					(menuItem as MenuItem).Text = $"{Settings.frameRate} FPS";
-				}),
-				new MenuItem($"          Version {Application.ProductVersion.Substring(0, Application.ProductVersion.Length - 4)}")
-			});
-		private void ShouldShowOverlayFrame(bool show)
-		{
-			if (_dxForm.WindowState == FormWindowState.Minimized)
-				_dxForm.WindowState = FormWindowState.Normal;
-			if (show && Settings.overlayClickable)
-			{
-				_overlayForm.AllowTransparency = false;
-				_overlayForm.FormBorderStyle = FormBorderStyle.Sizable;
-			}
-			else
-			{
-				try
-				{
-					_overlayForm.AllowTransparency = true;
-					_overlayForm.FormBorderStyle = FormBorderStyle.None;
-					_overlayForm.BackColor = Settings.transparencyKey;
-					_overlayForm.TransparencyKey = Settings.transparencyKey;
-				}
-				catch (Exception) { }
-			}
-		}
+        }
+        private int ColorToBgr(Color color) => (color.B << 16) | (color.G << 8) | color.R;
+        private MainMenu GetMenu() => new MainMenu(new MenuItem[]
+            {
+                new MenuItem("?", _dxForm_HelpRequested),
+                new MenuItem($"{(Settings.overlayClickable ? '☑' : '☐')} Overlay Clickable", (menuItem,e) => {
+                    Settings.overlayClickable = !Settings.overlayClickable;
+                    ShouldShowOverlayFrame(Settings.overlayClickable);
+                    Settings.Save();
+                    (menuItem as MenuItem).Text = $"{(Settings.overlayClickable ? '☑' : '☐')} Overlay Clickable";
+                }),
+                new MenuItem($"{(Settings.savePositions ? '☑' : '☐')} Save Window Positions", (menuItem,e) => {
+                    Settings.savePositions = !Settings.savePositions;
+                    Settings.Save();
+                    (menuItem as MenuItem).Text = $"{(Settings.savePositions ? '☑' : '☐')} Save Window Positions";
+                }),
+                new MenuItem("Transparency Colour", (menuItem,e) =>
+                {
+                    var dialog = new ColorDialog();
+                    dialog.Color = Settings.transparencyKey;
+                    dialog.SolidColorOnly = true;
+                    dialog.AnyColor = true;
+                    dialog.FullOpen = true;
+                    dialog.CustomColors = new int[] { ColorToBgr(Constants.DefaultTransparencyKey), ColorToBgr(Settings.transparencyKey) };
+                    if(dialog.ShowDialog(_dxForm) == DialogResult.OK)
+                    {
+                        Settings.transparencyKey = dialog.Color;
+                        Settings.Save();
+                        ShouldShowOverlayFrame(true);
+                    }
+                }),
+                new MenuItem($"{Settings.frameRate} FPS", (menuItem, e) => {
+                    switch(Settings.frameRate)
+                    {
+                        case 5: Settings.frameRate = 10; break;
+                        case 10: Settings.frameRate = 20; break;
+                        case 20: Settings.frameRate = 30; break;
+                        case 30: Settings.frameRate = 5; break;
+                    }
+                    Settings.Save();
+                    (menuItem as MenuItem).Text = $"{Settings.frameRate} FPS";
+                }),
+                new MenuItem($"          Version {Application.ProductVersion.Substring(0, Application.ProductVersion.Length - 4)}")
+            });
+        private void ShouldShowOverlayFrame(bool show)
+        {
+            if (_dxForm.WindowState == FormWindowState.Minimized)
+                _dxForm.WindowState = FormWindowState.Normal;
+            if (show && Settings.overlayClickable)
+            {
+                _overlayForm.AllowTransparency = false;
+                _overlayForm.FormBorderStyle = FormBorderStyle.Sizable;
+                _overlayForm.SetFormNormal();
+            }
+            else
+            {
+                try
+                {
+                    _overlayForm.AllowTransparency = true;
+                    _overlayForm.FormBorderStyle = FormBorderStyle.None;
+                    _overlayForm.BackColor = Settings.transparencyKey;
+                    _overlayForm.TransparencyKey = Settings.transparencyKey;
+                    _overlayForm.SetFormTransparent();
+                }
+                catch (Exception) { }
+            }
+        }
 
-		private void WindowHandleDestroyed(object sender, EventArgs e)
-		{
-			Dispose();
-			IsDisposed = true;
-			OnHostWindowClosed();
-		}
+        private void WindowHandleDestroyed(object sender, EventArgs e)
+        {
+            Dispose();
+            IsDisposed = true;
+            OnHostWindowClosed();
+        }
 
-		private void WindowHandleCreated(object sender, EventArgs e)
-		{
-			OnHostWindowCreated();
-		}
+        private void WindowHandleCreated(object sender, EventArgs e)
+        {
+            OnHostWindowCreated();
+        }
 
-		public void Update()
-		{
-			if (!UserResized) return;
-			_graphics.ResizeGraphics(ClientSize.Width, ClientSize.Height);
-			UserResized = false;
-			bmpScreenshot?.Dispose();
-			if (ClientSize.Width <= 0 || ClientSize.Height <= 0) return;
-			//// Set the bitmap object to the size of the screen
-			bmpScreenshot = new Bitmap(_dxForm.Width, _dxForm.Height, PixelFormat.Format32bppArgb);
-		}
+        public void Update()
+        {
+            if (!UserResized) return;
+            _graphics.ResizeGraphics(ClientSize.Width, ClientSize.Height);
+            UserResized = false;
+            bmpScreenshot?.Dispose();
+            if (ClientSize.Width <= 0 || ClientSize.Height <= 0) return;
+            //// Set the bitmap object to the size of the screen
+            bmpScreenshot = new Bitmap(_dxForm.Width, _dxForm.Height, PixelFormat.Format32bppArgb);
+        }
 
-		public void Draw()
-		{
-			_graphics.ClearRenderTargetView();
-			_graphics.PresentSwapChain();
-		}
+        public void Draw()
+        {
+            _graphics.ClearRenderTargetView();
+            _graphics.PresentSwapChain();
+        }
 
-		#region IDisposable Support
+        #region IDisposable Support
 
-		protected virtual void Dispose(bool disposing)
-		{
-			if (!IsDisposed)
-			{
-				if (disposing)
-				{
-					// TODO: dispose managed state (managed objects).
-					_dxForm.Dispose();
-				}
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!IsDisposed)
+            {
+                if (disposing)
+                {
+                    // TODO: dispose managed state (managed objects).
+                    _dxForm.Dispose();
+                }
 
-				_graphics.Dispose();
-				IsDisposed = true;
-			}
-		}
+                _graphics.Dispose();
+                IsDisposed = true;
+            }
+        }
 
-		// TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
-		~DirectXHost()
-		{
-			// Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-			Dispose(false);
-		}
+        // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
+        ~DirectXHost()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(false);
+        }
 
-		// This code added to correctly implement the disposable pattern.
-		public void Dispose()
-		{
-			// Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-			Dispose(true);
-			// TODO: uncomment the following line if the finalizer is overridden above.
-			GC.SuppressFinalize(this);
-		}
-		#endregion
+        // This code added to correctly implement the disposable pattern.
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(true);
+            // TODO: uncomment the following line if the finalizer is overridden above.
+            GC.SuppressFinalize(this);
+        }
+        #endregion
 
-	}
+    }
 }

--- a/DirectXHost.cs
+++ b/DirectXHost.cs
@@ -10,259 +10,267 @@ using DirectXHost.Extensions;
 using System.Threading;
 using System.Reflection;
 using System.ComponentModel;
+using System.Diagnostics;
 
 namespace DirectXHost
 {
-    public class DirectXHost : IDisposable
-    {
-        public const int GWL_EXSTYLE = -20;
-        public const uint WS_EX_LAYERED = 0x00080000;
-        public const uint WS_EX_TRANSPARENT = 0x00000020;
+	public class DirectXHost : IDisposable
+	{
+		public const int GWL_EXSTYLE = -20;
+		public const uint WS_EX_LAYERED = 0x00080000;
+		public const uint WS_EX_TRANSPARENT = 0x00000020;
 
-        [DllImport("user32.dll", SetLastError = true)]
-        static extern int GetWindowLong(IntPtr hWnd, int nIndex);
+		[DllImport("user32.dll", SetLastError = true)]
+		static extern int GetWindowLong(IntPtr hWnd, int nIndex);
 
-        [DllImport("user32.dll")]
-        static extern int SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
+		[DllImport("user32.dll")]
+		static extern int SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
 
-        [DllImport("user32.dll")]
-        static extern bool SetLayeredWindowAttributes(IntPtr hwnd, uint crKey, byte bAlpha, uint dwFlags);
+		[DllImport("user32.dll")]
+		static extern bool SetLayeredWindowAttributes(IntPtr hwnd, uint crKey, byte bAlpha, uint dwFlags);
 
-        [DllImport("user32")]
-        private static extern int PrintWindow(IntPtr hwnd, IntPtr hdcBlt, UInt32 nFlags);
-        [DllImport("user32.dll", SetLastError = true)]
-        static extern int SetWindowLong(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
-        [DllImport("user32.dll", SetLastError = true)]
-        static extern IntPtr FindWindow(string lpWindowClass, string lpWindowName);
-        [DllImport("user32.dll", SetLastError = true)]
-        static extern IntPtr FindWindowEx(IntPtr parentHandle, IntPtr childAfter, string className, string windowTitle);
-        private const int GWL_HWNDPARENT = -8;
+		[DllImport("user32")]
+		private static extern int PrintWindow(IntPtr hwnd, IntPtr hdcBlt, UInt32 nFlags);
+		[DllImport("user32.dll", SetLastError = true)]
+		static extern int SetWindowLong(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+		[DllImport("user32.dll", SetLastError = true)]
+		static extern IntPtr FindWindow(string lpWindowClass, string lpWindowName);
+		[DllImport("user32.dll", SetLastError = true)]
+		static extern IntPtr FindWindowEx(IntPtr parentHandle, IntPtr childAfter, string className, string windowTitle);
+		private const int GWL_HWNDPARENT = -8;
 
-        private OverlayForm _overlayForm;
-        private PictureBox _overlayTarget;
-        private RenderForm _dxForm;
-        private GraphicsD3D11 _graphics;
-        private long time = DateTime.Now.Ticks;
-        private bool UserResized { get; set; }
-        private Size ClientSize { get; set; }
+		private OverlayForm _overlayForm;
+		private PictureBox _overlayTarget;
+		private RenderForm _dxForm;
+		private GraphicsD3D11 _graphics;
+		private Stopwatch stopWatch = new Stopwatch();
+		private bool UserResized { get; set; }
+		private Size ClientSize { get; set; }
 
-        public bool IsDisposed { get; private set; }
+		public bool IsDisposed { get; private set; }
 
-        #region Events
-        public event EventHandler HostWindowClosed;
-        public event EventHandler HostWindowCreated;
-        protected void OnHostWindowCreated()
-        {
-            if (HostWindowCreated != null)
-            {
-                HostWindowCreated(this._dxForm, new EventArgs());
-            }
-        }
+		#region Events
+		public event EventHandler HostWindowClosed;
+		public event EventHandler HostWindowCreated;
+		protected void OnHostWindowCreated()
+		{
+			if (HostWindowCreated != null)
+			{
+				HostWindowCreated(this._dxForm, new EventArgs());
+			}
+		}
 
-        protected void OnHostWindowClosed()
-        {
-            if (HostWindowClosed != null)
-            {
-                HostWindowClosed(this._dxForm, new EventArgs());
-            }
-        }
-        #endregion
+		protected void OnHostWindowClosed()
+		{
+			if (HostWindowClosed != null)
+			{
+				HostWindowClosed(this._dxForm, new EventArgs());
+			}
+		}
+		#endregion
 
 
-        public void Exit()
-        {
-            throw new NotImplementedException();
-        }
+		public void Exit()
+		{
+			throw new NotImplementedException();
+		}
 
-        public async Task Run()
-        {
-            try
-            {
-                await Settings.Load();
-                InitializeRenderForm();
+		public async Task Run()
+		{
+			try
+			{
+				await Settings.Load();
+				InitializeRenderForm();
 
-                _graphics = new GraphicsD3D11();
-                _graphics.Initialise(_dxForm, true);
-                _dxForm.UserResized += (sender, args) =>
-                {
-                    var renderForm = sender as RenderForm;
-                    ClientSize = new Size(renderForm.ClientSize.Width, renderForm.ClientSize.Height);
-                    UserResized = true;
-                };
-                _overlayForm.Show();
-                RenderLoop.Run(_dxForm, RenderCallback, true);
-            }
-            catch (ArgumentException ex)
-            {
-                MessageBox.Show(string.Format("Exception running DirectX host window.\r\n{0}", ex.Message), "DirectX Host", MessageBoxButtons.OK, MessageBoxIcon.Error);
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show(string.Format("Exception running DirectX host window.\r\n{0}", ex.Message), "DirectX Host", MessageBoxButtons.OK, MessageBoxIcon.Error);
-            }
-        }
+				_graphics = new GraphicsD3D11();
+				_graphics.Initialise(_dxForm, true);
+				_dxForm.UserResized += (sender, args) =>
+				{
+					var renderForm = sender as RenderForm;
+					ClientSize = new Size(renderForm.ClientSize.Width, renderForm.ClientSize.Height);
+					UserResized = true;
+				};
+				_overlayForm.Show();
+				RenderLoop.Run(_dxForm, RenderCallback, true);
+			}
+			catch (ArgumentException ex)
+			{
+				MessageBox.Show(string.Format("Exception running DirectX host window.\r\n{0}", ex.Message), "DirectX Host", MessageBoxButtons.OK, MessageBoxIcon.Error);
+			}
+			catch (Exception ex)
+			{
+				MessageBox.Show(string.Format("Exception running DirectX host window.\r\n{0}", ex.Message), "DirectX Host", MessageBoxButtons.OK, MessageBoxIcon.Error);
+			}
+		}
 
-        // Set the bitmap object to the size of the screen
-        private Bitmap _bmpScreenshot;
-        Bitmap bmpScreenshot
-        {
-            get => _bmpScreenshot;
-            set
-            {
-                _bmpScreenshot = value;
-                _overlayTarget.Image = value;
-                updateImageBounds();
-            }
-        }
+		// Set the bitmap object to the size of the screen
+		private Bitmap _bmpScreenshot;
+		Bitmap bmpScreenshot
+		{
+			get => _bmpScreenshot;
+			set
+			{
+				_bmpScreenshot = value;
+				_overlayTarget.Image = value;
+				updateImageBounds();
+			}
+		}
 
-        Graphics gfxScreenshot;
-        private void RenderCallback()
-        {
-            if (_dxForm.WindowState != FormWindowState.Minimized)
-            {
-                Update();
-                Draw();
-                gfxScreenshot = Graphics.FromImage(bmpScreenshot);
-                IntPtr dc = gfxScreenshot.GetHdc();
-                PrintWindow(_dxForm.Handle, dc, 0);
-                gfxScreenshot.ReleaseHdc();
-                gfxScreenshot.Dispose();
-                _overlayTarget.Invalidate();
-            }
-            // Calculate Frame Limiting
-            //long end = DateTime.Now.Ticks;
-            //long duration = end - time;
-            int framerate = Settings.frameRate;
-            if (Settings.frameRate > 0)
-                Thread.Sleep(new TimeSpan(10000000 / Settings.frameRate));
-        }
+		Graphics gfxScreenshot;
+		private void RenderCallback()
+		{
+			stopWatch.Restart();
+			if (_dxForm.WindowState != FormWindowState.Minimized)
+			{
+				Update();
+				Draw();
+				gfxScreenshot = Graphics.FromImage(bmpScreenshot);
+				IntPtr dc = gfxScreenshot.GetHdc();
+				PrintWindow(_dxForm.Handle, dc, 0);
+				gfxScreenshot.ReleaseHdc();
+				gfxScreenshot.Dispose();
+				_overlayTarget.Invalidate();
+			}
+			// Calculate Frame Limiting
+			stopWatch.Stop();
+			long drawingTime = stopWatch.ElapsedTicks;
+			
+			int frameRate = Settings.frameRate;
 
-        class OverlayForm : Form
-        {
-            private int PreviousStyle;
+			if (frameRate > 0)
+			{
+				int framerateTicks = 10000000 / frameRate;
+				long duration = framerateTicks - drawingTime;
+				if (duration > 0)
+					Thread.Sleep(new TimeSpan(duration));
+			}
+		}
 
-            public OverlayForm() : base()
-            {
-                DoubleBuffered = true;
-            }
-            public void SetFormTransparent()
-            {
-                IntPtr Handle = this.Handle;
-                PreviousStyle = GetWindowLong(Handle, GWL_EXSTYLE);
-                SetWindowLong(Handle, GWL_EXSTYLE, Convert.ToInt32(PreviousStyle | WS_EX_LAYERED | WS_EX_TRANSPARENT));
-            }
+		class OverlayForm : Form
+		{
+			private int PreviousStyle;
 
-            public void SetFormNormal()
-            {
-                IntPtr Handle = this.Handle;
-                SetWindowLong(Handle, GWL_EXSTYLE, Convert.ToInt32(PreviousStyle | WS_EX_LAYERED));
-            }
-        }
-        private bool _drag = false;
-        private Point _wstart, _mstart;
+			public OverlayForm() : base()
+			{
+				DoubleBuffered = true;
+			}
+			public void SetFormTransparent()
+			{
+				PreviousStyle = GetWindowLong(Handle, GWL_EXSTYLE);
+				SetWindowLong(Handle, GWL_EXSTYLE, Convert.ToInt32(PreviousStyle | WS_EX_LAYERED | WS_EX_TRANSPARENT));
+			}
 
-        private void updateImageBounds()
-        {
-            _overlayTarget.Size = _dxForm.Size;
-            int BorderWidth = (_dxForm.Width - _dxForm.ClientSize.Width) / 2;
-            int TitlebarHeight = (_dxForm.Height - _dxForm.ClientSize.Height) - BorderWidth;
-            _overlayTarget.Location = new Point(-BorderWidth, -TitlebarHeight);
-            _overlayTarget.Width = _dxForm.Width - BorderWidth;
-            _overlayTarget.Height = _dxForm.Height - BorderWidth;
-            _overlayTarget.Invalidate();
-        }
+			public void SetFormNormal()
+			{
+				SetWindowLong(Handle, GWL_EXSTYLE, Convert.ToInt32(PreviousStyle | WS_EX_LAYERED));
+			}
+		}
+		private bool _drag = false;
+		private Point _wstart, _mstart;
 
-        private void InitializeRenderForm()
-        {
-            SizeF scaledSize;
-            _dxForm = new RenderForm(Constants.WindowTitle);
-            using (var gfx = _dxForm.CreateGraphics())
-            {
-                scaledSize = new SizeF(gfx.DpiX / 96, gfx.DpiY / 96);
-            }
-            _dxForm.HandleCreated += WindowHandleCreated;
-            _dxForm.HandleDestroyed += WindowHandleDestroyed;
-            _dxForm.MinimumSize = new Size((int)(Constants.StartWidth * scaledSize.Width), (int)(Constants.StartHeight * scaledSize.Height));
-            _dxForm.ClientSize = Settings.savePositions ? Settings.containerRect.Size : _dxForm.MinimumSize;
-            _dxForm.StartPosition = Settings.savePositions ? FormStartPosition.Manual : FormStartPosition.CenterScreen;
-            if (Settings.savePositions) _dxForm.Location = Settings.containerRect.Point;
-            if (Settings.hostTransparency == 0) Settings.hostTransparency = 1;
-            _dxForm.FormBorderStyle = FormBorderStyle.SizableToolWindow;
-            _dxForm.GotFocus += (s, e) => ShouldShowOverlayFrame(true);
-            _dxForm.LostFocus += (s, e) => ShouldShowOverlayFrame(false);
-            _dxForm.TopMost = false;
-            _dxForm.HelpRequested += _dxForm_HelpRequested;
-            _dxForm.Menu = GetMenu();
-            _dxForm.UserResized += (sender, args) => { Settings.containerRect.Size = _dxForm.ClientSize; _overlayForm.Width = _dxForm.Width; _overlayForm.Height = _dxForm.Height - SystemInformation.MenuHeight; Settings.Save(); };
-            _dxForm.LocationChanged += (sender, args) => { Settings.containerRect.Point = _dxForm.Location; Settings.Save(); };
+		private void updateImageBounds()
+		{
+			_overlayTarget.Size = _dxForm.Size;
+			int BorderWidth = (_dxForm.Width - _dxForm.ClientSize.Width) / 2;
+			int TitlebarHeight = (_dxForm.Height - _dxForm.ClientSize.Height) - BorderWidth;
+			_overlayTarget.Location = new Point(-BorderWidth, -TitlebarHeight);
+			_overlayTarget.Width = _dxForm.Width - BorderWidth;
+			_overlayTarget.Height = _dxForm.Height - BorderWidth;
+			_overlayTarget.Invalidate();
+		}
 
-            IntPtr hprog = FindWindowEx(FindWindowEx(FindWindow("Discord Overlay", "Program Manager"), IntPtr.Zero, "SHELLDLL_DefView", ""), IntPtr.Zero, "SysListView32", "FolderView");
-            SetWindowLong(_dxForm.Handle, GWL_HWNDPARENT, hprog);
+		private void InitializeRenderForm()
+		{
+			SizeF scaledSize;
+			_dxForm = new RenderForm(Constants.WindowTitle);
+			using (var gfx = _dxForm.CreateGraphics())
+			{
+				scaledSize = new SizeF(gfx.DpiX / 96, gfx.DpiY / 96);
+			}
+			_dxForm.HandleCreated += WindowHandleCreated;
+			_dxForm.HandleDestroyed += WindowHandleDestroyed;
+			_dxForm.MinimumSize = new Size((int)(Constants.StartWidth * scaledSize.Width), (int)(Constants.StartHeight * scaledSize.Height));
+			_dxForm.ClientSize = Settings.savePositions ? Settings.containerRect.Size : _dxForm.MinimumSize;
+			_dxForm.StartPosition = Settings.savePositions ? FormStartPosition.Manual : FormStartPosition.CenterScreen;
+			if (Settings.savePositions) _dxForm.Location = Settings.containerRect.Point;
+			if (Settings.hostOpacity == 0) Settings.hostOpacity = 1;
+			_dxForm.FormBorderStyle = FormBorderStyle.SizableToolWindow;
+			_dxForm.GotFocus += (s, e) => ShouldShowOverlayFrame(true);
+			_dxForm.LostFocus += (s, e) => ShouldShowOverlayFrame(false);
+			_dxForm.TopMost = false;
+			_dxForm.HelpRequested += _dxForm_HelpRequested;
+			_dxForm.Menu = GetMenu();
+			_dxForm.UserResized += (sender, args) => { Settings.containerRect.Size = _dxForm.ClientSize; _overlayForm.Width = _dxForm.Width; _overlayForm.Height = _dxForm.Height - SystemInformation.MenuHeight; Settings.Save(); };
+			_dxForm.LocationChanged += (sender, args) => { Settings.containerRect.Point = _dxForm.Location; Settings.Save(); };
 
-            _overlayForm = new OverlayForm();
-            _overlayForm.Text = _overlayForm.Name = "Discord Overlay";
-            _overlayForm.MinimumSize = new Size(100, 50);
-            _overlayForm.ClientSize = Settings.savePositions ? Settings.overlayRect.Size : new Size(Constants.OverlayStartWidth, Constants.OverlayStartHeight);
-            _overlayForm.StartPosition = Settings.savePositions ? FormStartPosition.Manual : FormStartPosition.CenterScreen;
-            if (Settings.savePositions) _overlayForm.Location = Settings.overlayRect.Point;
-            _overlayForm.BackColor = Settings.transparencyKey;
-            _overlayForm.TransparencyKey = Settings.transparencyKey;
-            _overlayForm.TopMost = true;
-            _overlayForm.ShowIcon = false;
-            _overlayForm.MinimizeBox = false;
-            _overlayForm.MaximizeBox = false;
-            _overlayForm.ControlBox = false;
-            _overlayForm.BackgroundImageLayout = ImageLayout.None;
-            _overlayForm.FormBorderStyle = FormBorderStyle.Sizable;
-            _overlayForm.FormClosing += (s, e) => _dxForm.Close();
-            _overlayForm.GotFocus += (s, e) => ShouldShowOverlayFrame(true);
-            _overlayForm.LostFocus += (s, e) => ShouldShowOverlayFrame(false);
-            _overlayTarget = new PictureBox();
-            _overlayTarget.SizeMode = PictureBoxSizeMode.Normal;
-            _overlayTarget.BackColor = Settings.transparencyKey;
-            _overlayTarget.Anchor = AnchorStyles.Top | AnchorStyles.Left;
-            _overlayForm.Controls.Add(_overlayTarget);
-            _overlayForm.ResizeEnd += (sender, args) => { Settings.overlayRect.Size = _overlayForm.ClientSize; Settings.Save(); };
-            _overlayForm.LocationChanged += (sender, args) => { Settings.overlayRect.Point = _overlayForm.Location; Settings.Save(); };
-            _overlayForm.Width = _dxForm.Width; _overlayForm.Height = _dxForm.Height - SystemInformation.MenuHeight;
-            
-            // Set the bitmap object to the size of the screen
-            bmpScreenshot = new Bitmap(_dxForm.Width, _dxForm.Height, PixelFormat.Format32bppArgb);
+			IntPtr hprog = FindWindowEx(FindWindowEx(FindWindow("Discord Overlay", "Program Manager"), IntPtr.Zero, "SHELLDLL_DefView", ""), IntPtr.Zero, "SysListView32", "FolderView");
+			SetWindowLong(_dxForm.Handle, GWL_HWNDPARENT, hprog);
 
-            _dxForm.MouseDown += (s, e) =>
-            {
-                _drag = e.Button == MouseButtons.Left;
-                _mstart = _dxForm.PointToScreen(e.Location);
-                _wstart = _dxForm.Location;
-            };
-            _dxForm.MouseUp += (s, e) => _drag = e.Button == MouseButtons.Left ? false : _drag;
-            _dxForm.MouseMove += (s, e) =>
-            {
-                if (!_drag) return;
-                var newPoint = e.Location;
-                var delta = new Point(newPoint.X - _mstart.X, newPoint.Y - _mstart.Y);
-                _dxForm.Location = _dxForm.PointToScreen(new Point(_wstart.X + delta.X, _wstart.Y + delta.Y));
-            };
+			_overlayForm = new OverlayForm();
+			_overlayForm.Text = _overlayForm.Name = "Discord Overlay";
+			_overlayForm.MinimumSize = new Size(100, 50);
+			_overlayForm.ClientSize = Settings.savePositions ? Settings.overlayRect.Size : new Size(Constants.OverlayStartWidth, Constants.OverlayStartHeight);
+			_overlayForm.StartPosition = Settings.savePositions ? FormStartPosition.Manual : FormStartPosition.CenterScreen;
+			if (Settings.savePositions) _overlayForm.Location = Settings.overlayRect.Point;
+			_overlayForm.BackColor = Settings.transparencyKey;
+			_overlayForm.TransparencyKey = Settings.transparencyKey;
+			_overlayForm.TopMost = true;
+			_overlayForm.ShowIcon = false;
+			_overlayForm.MinimizeBox = false;
+			_overlayForm.MaximizeBox = false;
+			_overlayForm.ControlBox = false;
+			_overlayForm.BackgroundImageLayout = ImageLayout.None;
+			_overlayForm.FormBorderStyle = FormBorderStyle.Sizable;
+			_overlayForm.FormClosing += (s, e) => _dxForm.Close();
+			_overlayForm.GotFocus += (s, e) => ShouldShowOverlayFrame(true);
+			_overlayForm.LostFocus += (s, e) => ShouldShowOverlayFrame(false);
+			_overlayTarget = new PictureBox();
+			_overlayTarget.SizeMode = PictureBoxSizeMode.Normal;
+			_overlayTarget.BackColor = Settings.transparencyKey;
+			_overlayTarget.Anchor = AnchorStyles.Top | AnchorStyles.Left;
+			_overlayForm.Controls.Add(_overlayTarget);
+			_overlayForm.ResizeEnd += (sender, args) => { Settings.overlayRect.Size = _overlayForm.ClientSize; Settings.Save(); };
+			_overlayForm.LocationChanged += (sender, args) => { Settings.overlayRect.Point = _overlayForm.Location; Settings.Save(); };
+			_overlayForm.Width = _dxForm.Width;
+			_overlayForm.Height = _dxForm.Height - SystemInformation.MenuHeight;
 
-            _overlayForm.MouseDown += (s, e) =>
-            {
-                _drag = e.Button == MouseButtons.Left;
-                _mstart = _overlayForm.PointToScreen(e.Location);
-                _wstart = _overlayForm.Location;
-            };
-            _overlayForm.MouseUp += (s, e) => _drag = e.Button == MouseButtons.Left ? false : _drag;
-            _overlayForm.MouseMove += (s, e) =>
-            {
-                if (!_drag) return;
-                var newPoint = e.Location;
-                var delta = new Point(newPoint.X - _mstart.X, newPoint.Y - _mstart.Y);
-                _overlayForm.Location = _overlayForm.PointToScreen(new Point(_wstart.X + delta.X, _wstart.Y + delta.Y));
-            };
-        }
+			// Set the bitmap object to the size of the screen
+			bmpScreenshot = new Bitmap(_dxForm.Width, _dxForm.Height, PixelFormat.Format32bppArgb);
 
-        private void _dxForm_HelpRequested(object sender, EventArgs eventArgs)
-        {
-            MessageBox.Show(_dxForm, @"Overlay Clickable: Enables/Disables ability to interact with the Overlay Window.
+			_dxForm.MouseDown += (s, e) =>
+			{
+				_drag = e.Button == MouseButtons.Left;
+				_mstart = _dxForm.PointToScreen(e.Location);
+				_wstart = _dxForm.Location;
+			};
+			_dxForm.MouseUp += (s, e) => _drag = e.Button == MouseButtons.Left ? false : _drag;
+			_dxForm.MouseMove += (s, e) =>
+			{
+				if (!_drag) return;
+				var newPoint = e.Location;
+				var delta = new Point(newPoint.X - _mstart.X, newPoint.Y - _mstart.Y);
+				_dxForm.Location = _dxForm.PointToScreen(new Point(_wstart.X + delta.X, _wstart.Y + delta.Y));
+			};
+
+			_overlayForm.MouseDown += (s, e) =>
+			{
+				_drag = e.Button == MouseButtons.Left;
+				_mstart = _overlayForm.PointToScreen(e.Location);
+				_wstart = _overlayForm.Location;
+			};
+			_overlayForm.MouseUp += (s, e) => _drag = e.Button == MouseButtons.Left ? false : _drag;
+			_overlayForm.MouseMove += (s, e) =>
+			{
+				if (!_drag) return;
+				var newPoint = e.Location;
+				var delta = new Point(newPoint.X - _mstart.X, newPoint.Y - _mstart.Y);
+				_overlayForm.Location = _overlayForm.PointToScreen(new Point(_wstart.X + delta.X, _wstart.Y + delta.Y));
+			};
+		}
+
+		private void _dxForm_HelpRequested(object sender, EventArgs eventArgs)
+		{
+			MessageBox.Show(_dxForm, @"Overlay Clickable: Enables/Disables ability to interact with the Overlay Window.
 
 Save Window Positions: Saves the Overlay and Container sizes and screen positions.
 
@@ -272,159 +280,159 @@ FPS: The rate at which the Discord Overlay refreshes. This is defaulted to 10 ti
 
 If you have issues with the window positions/sizes, delete the 'props.bin' file that is generated in the program's folder. This will reset the program settings.
 ", "Help", MessageBoxButtons.OK, MessageBoxIcon.Question);
-        }
-        private int ColorToBgr(Color color) => (color.B << 16) | (color.G << 8) | color.R;
-        private MainMenu GetMenu() => new MainMenu(new MenuItem[]
-            {
-                new MenuItem("?", _dxForm_HelpRequested),
-                new MenuItem($"{(Settings.overlayClickable ? '☑' : '☐')} Overlay Clickable", (menuItem,e) => {
-                    Settings.overlayClickable = !Settings.overlayClickable;
-                    ShouldShowOverlayFrame(Settings.overlayClickable);
-                    Settings.Save();
-                    (menuItem as MenuItem).Text = $"{(Settings.overlayClickable ? '☑' : '☐')} Overlay Clickable";
-                }),
-                new MenuItem($"{(Settings.savePositions ? '☑' : '☐')} Save Window Positions", (menuItem,e) => {
-                    Settings.savePositions = !Settings.savePositions;
-                    Settings.Save();
-                    (menuItem as MenuItem).Text = $"{(Settings.savePositions ? '☑' : '☐')} Save Window Positions";
-                }),
-                new MenuItem("Transparency Colour", (menuItem,e) =>
-                {
-                    var dialog = new ColorDialog();
-                    dialog.Color = Settings.transparencyKey;
-                    dialog.SolidColorOnly = true;
-                    dialog.AnyColor = true;
-                    dialog.FullOpen = true;
-                    dialog.CustomColors = new int[] { ColorToBgr(Constants.DefaultTransparencyKey), ColorToBgr(Settings.transparencyKey) };
-                    if(dialog.ShowDialog(_dxForm) == DialogResult.OK)
-                    {
-                        Settings.transparencyKey = dialog.Color;
-                        Settings.Save();
-                        ShouldShowOverlayFrame(true);
-                    }
-                }),
-                new MenuItem($"{(Settings.frameRate > 0?Settings.frameRate.ToString():"Unlimited")} FPS", (menuItem, e) => {
-                    switch(Settings.frameRate)
-                    {
-                        case 5: Settings.frameRate = 10; break;
-                        case 10: Settings.frameRate = 20; break;
-                        case 20: Settings.frameRate = 30; break;
-                        case 30: Settings.frameRate = 60; break;
-                        case 60: Settings.frameRate = 120; break;
-                        case 120: Settings.frameRate = 0; break;
-                        case 0: Settings.frameRate = 5; break;
-                    }
-                    Settings.Save();
-                    (menuItem as MenuItem).Text = $"{(Settings.frameRate > 0?Settings.frameRate.ToString():"Unlimited")} FPS";
-                }),
-                new MenuItem($"{Settings.hostTransparency * 100}% Opacity", (menuItem, e) => {
-                    if (_dxForm.Opacity != Settings.hostTransparency)
-                    {
-                        _dxForm.AllowTransparency = Settings.hostTransparent;
-                        _dxForm.Opacity = Settings.hostTransparency;
-                        return;
-                    }
-                    switch(Settings.hostTransparency)
-                    {
-                        case 1: Settings.hostTransparency = 0.75;  Settings.hostTransparent = true; break;
-                        case 0.75: Settings.hostTransparency = 0.5;  Settings.hostTransparent = true; break;
-                        case 0.5: Settings.hostTransparency = 0.25;  Settings.hostTransparent = true; break;
-                        case 0.25: Settings.hostTransparency = 1;  Settings.hostTransparent = false; break;
-                        default: Settings.hostTransparency = 1.0;  Settings.hostTransparent = false; break;
-                    }
-                    Settings.Save();
-                    _dxForm.AllowTransparency = Settings.hostTransparent;
-                    _dxForm.Opacity = Settings.hostTransparency;
-                    (menuItem as MenuItem).Text = $"{Settings.hostTransparency * 100}% Opacity";
-                }),
-                new MenuItem($"          Version {Application.ProductVersion.Substring(0, Application.ProductVersion.Length - 4)}")
-            });
-        private void ShouldShowOverlayFrame(bool show)
-        {
-            if (_dxForm.WindowState == FormWindowState.Minimized)
-                _dxForm.WindowState = FormWindowState.Normal;
-            if (show && Settings.overlayClickable)
-            {
-                _overlayForm.AllowTransparency = false;
-                _overlayForm.FormBorderStyle = FormBorderStyle.FixedToolWindow;
-                _overlayForm.SetFormNormal();
-            }
-            else
-            {
-                try
-                {
-                    _overlayForm.AllowTransparency = true;
-                    _overlayForm.FormBorderStyle = FormBorderStyle.None;
-                    _overlayForm.BackColor = Settings.transparencyKey;
-                    _overlayForm.TransparencyKey = Settings.transparencyKey;
-                    _overlayForm.SetFormTransparent();
-                }
-                catch (Exception) { }
-            }
-        }
+		}
+		private int ColorToBgr(Color color) => (color.B << 16) | (color.G << 8) | color.R;
+		private MainMenu GetMenu() => new MainMenu(new MenuItem[]
+			{
+				new MenuItem("?", _dxForm_HelpRequested),
+				new MenuItem($"{(Settings.overlayClickable ? '☑' : '☐')} Overlay Clickable", (menuItem,e) => {
+					Settings.overlayClickable = !Settings.overlayClickable;
+					ShouldShowOverlayFrame(Settings.overlayClickable);
+					Settings.Save();
+					(menuItem as MenuItem).Text = $"{(Settings.overlayClickable ? '☑' : '☐')} Overlay Clickable";
+				}),
+				new MenuItem($"{(Settings.savePositions ? '☑' : '☐')} Save Window Positions", (menuItem,e) => {
+					Settings.savePositions = !Settings.savePositions;
+					Settings.Save();
+					(menuItem as MenuItem).Text = $"{(Settings.savePositions ? '☑' : '☐')} Save Window Positions";
+				}),
+				new MenuItem("Transparency Colour", (menuItem,e) =>
+				{
+					var dialog = new ColorDialog();
+					dialog.Color = Settings.transparencyKey;
+					dialog.SolidColorOnly = true;
+					dialog.AnyColor = true;
+					dialog.FullOpen = true;
+					dialog.CustomColors = new int[] { ColorToBgr(Constants.DefaultTransparencyKey), ColorToBgr(Settings.transparencyKey) };
+					if(dialog.ShowDialog(_dxForm) == DialogResult.OK)
+					{
+						Settings.transparencyKey = dialog.Color;
+						Settings.Save();
+						ShouldShowOverlayFrame(true);
+					}
+				}),
+				new MenuItem($"{(Settings.frameRate > 0 ? Settings.frameRate.ToString() : "Unlimited")} FPS", (menuItem, e) => {
+					switch(Settings.frameRate)
+					{
+						case 5: Settings.frameRate = 10; break;
+						case 10: Settings.frameRate = 20; break;
+						case 20: Settings.frameRate = 30; break;
+						case 30: Settings.frameRate = 60; break;
+						case 60: Settings.frameRate = 120; break;
+						case 120: Settings.frameRate = 0; break;
+						case 0: Settings.frameRate = 5; break;
+					}
+					Settings.Save();
+					(menuItem as MenuItem).Text = $"{(Settings.frameRate > 0 ? Settings.frameRate.ToString() : "Unlimited")} FPS";
+				}),
+				new MenuItem($"{Settings.hostOpacity * 100}% Opacity", (menuItem, e) => {
+					if (_dxForm.Opacity != Settings.hostOpacity)
+					{
+						_dxForm.AllowTransparency = Settings.isHostTransparent;
+						_dxForm.Opacity = Settings.hostOpacity;
+						return;
+					}
+					switch(Settings.hostOpacity)
+					{
+						case 1: Settings.hostOpacity = 0.75; break;
+						case 0.75: Settings.hostOpacity = 0.5; break;
+						case 0.5: Settings.hostOpacity = 0.25; break;
+						case 0.25: Settings.hostOpacity = 1; break;
+						default: Settings.hostOpacity = 1.0; break;
+					}
+					Settings.Save();
+					_dxForm.AllowTransparency = Settings.isHostTransparent;
+					_dxForm.Opacity = Settings.hostOpacity;
+					(menuItem as MenuItem).Text = $"{Settings.hostOpacity * 100}% Opacity";
+				}),
+				new MenuItem($"          Version {Application.ProductVersion.Substring(0, Application.ProductVersion.Length - 4)}")
+			});
+		private void ShouldShowOverlayFrame(bool show)
+		{
+			if (_dxForm.WindowState == FormWindowState.Minimized)
+				_dxForm.WindowState = FormWindowState.Normal;
+			if (show && Settings.overlayClickable)
+			{
+				_overlayForm.AllowTransparency = false;
+				_overlayForm.FormBorderStyle = FormBorderStyle.FixedToolWindow;
+				_overlayForm.SetFormNormal();
+			}
+			else
+			{
+				try
+				{
+					_overlayForm.AllowTransparency = true;
+					_overlayForm.FormBorderStyle = FormBorderStyle.None;
+					_overlayForm.BackColor = Settings.transparencyKey;
+					_overlayForm.TransparencyKey = Settings.transparencyKey;
+					_overlayForm.SetFormTransparent();
+				}
+				catch (Exception) { }
+			}
+		}
 
-        private void WindowHandleDestroyed(object sender, EventArgs e)
-        {
-            Dispose();
-            IsDisposed = true;
-            OnHostWindowClosed();
-        }
+		private void WindowHandleDestroyed(object sender, EventArgs e)
+		{
+			Dispose();
+			IsDisposed = true;
+			OnHostWindowClosed();
+		}
 
-        private void WindowHandleCreated(object sender, EventArgs e)
-        {
-            OnHostWindowCreated();
-        }
+		private void WindowHandleCreated(object sender, EventArgs e)
+		{
+			OnHostWindowCreated();
+		}
 
-        public void Update()
-        {
-            if (!UserResized) return;
-            _graphics.ResizeGraphics(ClientSize.Width, ClientSize.Height);
-            UserResized = false;
-            bmpScreenshot?.Dispose();
-            if (ClientSize.Width <= 0 || ClientSize.Height <= 0) return;
-            //// Set the bitmap object to the size of the screen
-            bmpScreenshot = new Bitmap(_dxForm.Width, _dxForm.Height, PixelFormat.Format32bppArgb);
-        }
+		public void Update()
+		{
+			if (!UserResized) return;
+			_graphics.ResizeGraphics(ClientSize.Width, ClientSize.Height);
+			UserResized = false;
+			bmpScreenshot?.Dispose();
+			if (ClientSize.Width <= 0 || ClientSize.Height <= 0) return;
+			//// Set the bitmap object to the size of the screen
+			bmpScreenshot = new Bitmap(_dxForm.Width, _dxForm.Height, PixelFormat.Format32bppArgb);
+		}
 
-        public void Draw()
-        {
-            _graphics.ClearRenderTargetView();
-            _graphics.PresentSwapChain();
-        }
+		public void Draw()
+		{
+			_graphics.ClearRenderTargetView();
+			_graphics.PresentSwapChain();
+		}
 
-        #region IDisposable Support
+		#region IDisposable Support
 
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!IsDisposed)
-            {
-                if (disposing)
-                {
-                    // TODO: dispose managed state (managed objects).
-                    _dxForm.Dispose();
-                }
+		protected virtual void Dispose(bool disposing)
+		{
+			if (!IsDisposed)
+			{
+				if (disposing)
+				{
+					// TODO: dispose managed state (managed objects).
+					_dxForm.Dispose();
+				}
 
-                _graphics.Dispose();
-                IsDisposed = true;
-            }
-        }
+				_graphics.Dispose();
+				IsDisposed = true;
+			}
+		}
 
-        // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
-        ~DirectXHost()
-        {
-            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-            Dispose(false);
-        }
+		// TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
+		~DirectXHost()
+		{
+			// Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+			Dispose(false);
+		}
 
-        // This code added to correctly implement the disposable pattern.
-        public void Dispose()
-        {
-            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-            Dispose(true);
-            // TODO: uncomment the following line if the finalizer is overridden above.
-            GC.SuppressFinalize(this);
-        }
-        #endregion
+		// This code added to correctly implement the disposable pattern.
+		public void Dispose()
+		{
+			// Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+			Dispose(true);
+			// TODO: uncomment the following line if the finalizer is overridden above.
+			GC.SuppressFinalize(this);
+		}
+		#endregion
 
-    }
+	}
 }

--- a/DirectXHost.cs
+++ b/DirectXHost.cs
@@ -186,6 +186,7 @@ namespace DirectXHost
             _dxForm.ClientSize = Settings.savePositions ? Settings.containerRect.Size : _dxForm.MinimumSize;
             _dxForm.StartPosition = Settings.savePositions ? FormStartPosition.Manual : FormStartPosition.CenterScreen;
             if (Settings.savePositions) _dxForm.Location = Settings.containerRect.Point;
+            if (Settings.hostTransparency == 0) Settings.hostTransparency = 1;
             _dxForm.FormBorderStyle = FormBorderStyle.SizableToolWindow;
             _dxForm.GotFocus += (s, e) => ShouldShowOverlayFrame(true);
             _dxForm.LostFocus += (s, e) => ShouldShowOverlayFrame(false);

--- a/Settings.cs
+++ b/Settings.cs
@@ -18,7 +18,7 @@ namespace DirectXHost
 			public Rect containerRect;
 			public Color transparencyKey;
 			public int frameRate;
-			public double hostTransparency;
+			public double hostOpacity;
 		}
 		private static AutoResetEvent gate = new AutoResetEvent(false);
 		private static Data data;
@@ -56,8 +56,8 @@ namespace DirectXHost
 		
 		public static double hostOpacity
 		{
-			get => data.hostTransparency;
-			set => data.hostTransparency = value;
+			get => data.hostOpacity;
+			set => data.hostOpacity = value;
 		}
 
 		public static bool isHostTransparent => hostOpacity < 1;
@@ -74,7 +74,7 @@ namespace DirectXHost
 					containerRect = new Rect { Size = new Size(Constants.StartWidth, Constants.StartHeight), Point = Point.Empty },
 					transparencyKey = Constants.DefaultTransparencyKey,
 					frameRate = 10,
-					hostTransparency = 1
+					hostOpacity = 1
 				};
 				return;
 			}

--- a/Settings.cs
+++ b/Settings.cs
@@ -18,6 +18,8 @@ namespace DirectXHost
 			public Rect containerRect;
 			public Color transparencyKey;
 			public int frameRate;
+			public double hostTransparency;
+			public bool hostTransparent;
 		}
 		private static AutoResetEvent gate = new AutoResetEvent(false);
 		private static Data data;
@@ -52,6 +54,18 @@ namespace DirectXHost
 			get => data.frameRate;
 			set => data.frameRate = value;
 		}
+		
+		public static double hostTransparency
+		{
+			get => data.hostTransparency;
+			set => data.hostTransparency = value;
+		}
+		
+		public static bool hostTransparent
+		{
+			get => data.hostTransparent;
+			set => data.hostTransparent = value;
+		}
 
 		public static async Task Load() => await Task.Run(() =>
 		{
@@ -64,7 +78,9 @@ namespace DirectXHost
 					overlayRect = new Rect { Size = new Size(Constants.OverlayStartWidth, Constants.OverlayStartHeight), Point = Point.Empty },
 					containerRect = new Rect { Size = new Size(Constants.StartWidth, Constants.StartHeight), Point = Point.Empty },
 					transparencyKey = Constants.DefaultTransparencyKey,
-					frameRate = 10
+					frameRate = 10,
+					hostTransparency = 1,
+					hostTransparent = false
 				};
 				return;
 			}

--- a/Settings.cs
+++ b/Settings.cs
@@ -55,17 +55,13 @@ namespace DirectXHost
 			set => data.frameRate = value;
 		}
 		
-		public static double hostTransparency
+		public static double hostOpacity
 		{
 			get => data.hostTransparency;
 			set => data.hostTransparency = value;
 		}
-		
-		public static bool hostTransparent
-		{
-			get => data.hostTransparent;
-			set => data.hostTransparent = value;
-		}
+
+		public static bool isHostTransparent => hostOpacity < 1;
 
 		public static async Task Load() => await Task.Run(() =>
 		{

--- a/Settings.cs
+++ b/Settings.cs
@@ -19,7 +19,6 @@ namespace DirectXHost
 			public Color transparencyKey;
 			public int frameRate;
 			public double hostTransparency;
-			public bool hostTransparent;
 		}
 		private static AutoResetEvent gate = new AutoResetEvent(false);
 		private static Data data;
@@ -75,8 +74,7 @@ namespace DirectXHost
 					containerRect = new Rect { Size = new Size(Constants.StartWidth, Constants.StartHeight), Point = Point.Empty },
 					transparencyKey = Constants.DefaultTransparencyKey,
 					frameRate = 10,
-					hostTransparency = 1,
-					hostTransparent = false
+					hostTransparency = 1
 				};
 				return;
 			}


### PR DESCRIPTION
Fix Mouse Capture. 
All mouse actions on the overlay when is not clickable fall thought the bottom application (when flicking the mouse over the overlay no longer takes focus)

Fixed Framerate limiter
Framerate limiting now correctly applies using the sleep ticks (10000 ticks in a ms, 10000000 ticks in a second) (https://learn.microsoft.com/en-us/dotnet/api/system.timespan.ticks?view=netframework-4.5.2), added more framerate options.

Added Host Opacity Option.
A big blob of a gray area can be distracting even if it can be buried by other windows, added an option to make it 25, 50, 75 and 100% (Off) opaque. However, if the application doesn't start at 100% opacity, Discord may not detect it, so always starts with 100% opacity.

Overlay Host now controls Overlay Form Size
Resizing the host automatically resizes the Overlay to the correct size